### PR TITLE
Updates

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,28 @@
 
 
 [[projects]]
-  branch = "master"
   name = "github.com/dsnet/compress"
-  packages = [".","bzip2","bzip2/internal/sais","internal","internal/errors","internal/prefix"]
-  revision = "c4dbed65594871659ea7347a85e1b8dcd97b9990"
+  packages = [
+    ".",
+    "bzip2",
+    "bzip2/internal/sais",
+    "internal",
+    "internal/errors",
+    "internal/prefix"
+  ]
+  revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
 
 [[projects]]
   branch = "master"
   name = "github.com/groob/plist"
   packages = ["."]
-  revision = "cd4f0bb6166577d40876bd169683d481e8082502"
+  revision = "2805b357fb2349d3a53ad2d5a5d00d191d9a37c9"
+
+[[projects]]
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -25,9 +37,21 @@
   revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
   version = "v1.1.0"
 
+[[projects]]
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  revision = "7b2c5ac9fc04fc5efafb60700713d4fa609b777b"
+  version = "v0.0.1"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
+  version = "v1.0.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "be2f9acc25b076885da5719081a22de2c73ac97314420ecd87196c0c5ac4f7b3"
+  inputs-digest = "8ac54c0aa6f0df92b04730e8a77398ad07fdad12b6273ea3dbcc61de0a59915a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,18 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+[[constraint]]
+  name = "github.com/dsnet/compress"
+  revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "v0.8.0"
 
 [[constraint]]
   name = "github.com/satori/go.uuid"
   version = "1.1.0"
+
+[[constraint]]
+  name = "github.com/spf13/cobra"
+  version = "v0.0.1"

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,97 @@
 all: build
 
+.PHONY: build
+
+ifndef ($(GOPATH))
+	GOPATH = $(HOME)/go
+endif
+
+PATH := $(GOPATH)/bin:$(PATH)
+VERSION = $(shell git describe --tags --always --dirty)
+BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+REVISION = $(shell git rev-parse HEAD)
+REVSHORT = $(shell git rev-parse --short HEAD)
+USER = $(shell whoami)
+APP_NAME = gosal
+PKGDIR_TMP = ${TMPDIR}golang
+
+ifneq ($(OS), Windows_NT)
+	CURRENT_PLATFORM = linux
+	# If on macOS, set the shell to bash explicitly
+	ifeq ($(shell uname), Darwin)
+		SHELL := /bin/bash
+		CURRENT_PLATFORM = darwin
+	endif
+
+	# To populate version metadata, we use unix tools to get certain data
+	GOVERSION = $(shell go version | awk '{print $$3}')
+	NOW	= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+else
+	CURRENT_PLATFORM = windows
+
+	# To populate version metadata, we use windows tools to get the certain data
+	GOVERSION_CMD = "(go version).Split()[2]"
+	GOVERSION = $(shell powershell $(GOVERSION_CMD))
+	NOW	= $(shell powershell Get-Date -format s)
+endif
+
+BUILD_VERSION = "\
+	-X github.com/airbnb/gosal/version.appName=${APP_NAME} \
+	-X github.com/airbnb/gosal/version.version=${VERSION} \
+	-X github.com/airbnb/gosal/version.branch=${BRANCH} \
+	-X github.com/airbnb/gosal/version.buildUser=${USER} \
+	-X github.com/airbnb/gosal/version.buildDate=${NOW} \
+	-X github.com/airbnb/gosal/version.revision=${REVISION} \
+	-X github.com/airbnb/gosal/version.goVersion=${GOVERSION}"
+
+define HELP_TEXT
+
+  Makefile commands
+
+	make deps         - Install dependent programs and libraries
+	make clean        - Delete all build artifacts
+
+	make build        - Build the code
+
+	make test         - Run the Go tests
+	make lint         - Run the Go linters
+
+endef
+
+help:
+	$(info $(HELP_TEXT))
+
 deps:
 	go get -u github.com/golang/dep/...
 	go get -u github.com/golang/lint/golint
-	dep ensure -v
+	dep ensure -vendor-only -v
 
-build:
-	mkdir -p build
-	go build -i -o build/gosal
-	GOOS=windows go build -o build/gosal.exe
+clean:
+	rm -rf build/
+	rm -f *.zip
+	rm -rf ${PKGDIR_TMP}_darwin
+	rm -rf ${PKGDIR_TMP}_linux
+	rm -rf ${PKGDIR_TMP}_windows
+
+.pre-build:
+	mkdir -p build/darwin
+	mkdir -p build/linux
+	mkdir -p build/windows
+
+
+build: .pre-build
+	GOOS=darwin go build -i -o build/darwin/${APP_NAME} -pkgdir ${PKGDIR_TMP}_darwin -ldflags ${BUILD_VERSION}
+	# GOOS=linux go build -i -o build/linux/${APP_NAME} -pkgdir ${PKGDIR_TMP}_linux -ldflags ${BUILD_VERSION}
+	GOOS=windows go build -i -o build/windows/${APP_NAME}.exe -pkgdir ${PKGDIR_TMP}_windows -ldflags ${BUILD_VERSION}
+
 
 test:
 	go test -cover -race -v $(shell go list ./... | grep -v /vendor/)
 
-.PHONY: build
 
 lint:
 	@if gofmt -l . | egrep -v ^vendor/ | grep .go; then \
 	  echo "^- Repo contains improperly formatted go files; run gofmt -w *.go" && exit 1; \
 	  else echo "All .go files formatted correctly"; fi
+	go vet ./...
 	for pkg in $$(go list ./... |grep -v /vendor/); do golint $$pkg; done

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Gosal is intended to be a multi platform client for sal.
 
 ## Getting Started
 
-Currently gosal uses a `LoadConfig` funtion that accepts a path, and expects `json`.  This needs to be at the absolute path to the Gosal.exe, it looks like this...
+Currently gosal uses a `LoadConfig` function that accepts a path to a to json file. This json file should be named `config.json` and located at the absolute path to the gosal.exe executable. Use the following format:
 
-```
+```json
 {
   "key": "your gigantic machine group key",
   "url": "https://urltoyourserver.com/"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/airbnb/gosal/sal"
+	"github.com/spf13/cobra"
+)
+
+var cfgFile string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "gosal",
+	Short: "gosal uploads machine details to sal",
+	Long: `Gosal is intended to be a multi platform client for sal.
+
+Complete documentation is available at https://github.com/airbnb/gosal/.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		sal.SendCheckin()
+	},
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"github.com/airbnb/gosal/version"
+	"github.com/spf13/cobra"
+)
+
+var (
+	fFull bool
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version number of gosal",
+	Long:  `Print the version number and build information of gosal`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if fFull {
+			version.PrintFull()
+			return
+		}
+		version.Print()
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+	versionCmd.PersistentFlags().BoolVar(&fFull, "full", false, "print full version information")
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
-import "github.com/airbnb/gosal/sal"
+import (
+	"github.com/airbnb/gosal/cmd"
+)
 
 func main() {
-	sal.SendCheckin()
+	cmd.Execute()
 }

--- a/sal/sal.go
+++ b/sal/sal.go
@@ -97,8 +97,8 @@ func SendCheckin() {
 		log.Fatal(err)
 	}
 
-	s := []string{dir, "config.json"}
-	conf, err := LoadConfig(strings.Join(s, "\\"))
+	s := filepath.Join(dir, "config.json")
+	conf, err := LoadConfig(s)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,112 @@
+/*
+MIT License
+
+Copyright (c) 2017 Kolide
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+/*
+	Package version provides utilities for displaying version information about a Go application.
+
+	To use this package, a program would set the package variables at build time, using the
+	-ldflags go build flag.
+
+	Example:
+		go build -ldflags "-X github.com/kolide/kit/version.version=1.0.0"
+
+	Available values and defaults to use with ldflags:
+
+		version   = "unknown"
+		branch    = "unknown"
+		revision  = "unknown"
+		goVersion = "unknown"
+		buildDate = "unknown"
+		buildUser = "unknown"
+		appName   = "unknown"
+
+*/
+package version
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// These values are private which ensures they can only be set with the build flags.
+var (
+	version   = "unknown"
+	branch    = "unknown"
+	revision  = "unknown"
+	goVersion = "unknown"
+	buildDate = "unknown"
+	buildUser = "unknown"
+	appName   = "unknown"
+)
+
+// Info is a structure with version build information about the current application.
+type Info struct {
+	Version   string `json:"version"`
+	Branch    string `json:"branch"`
+	Revision  string `json:"revision"`
+	GoVersion string `json:"go_version"`
+	BuildDate string `json:"build_date"`
+	BuildUser string `json:"build_user"`
+}
+
+// Version returns a structure with the current version information.
+func Version() Info {
+	return Info{
+		Version:   version,
+		Branch:    branch,
+		Revision:  revision,
+		GoVersion: goVersion,
+		BuildDate: buildDate,
+		BuildUser: buildUser,
+	}
+}
+
+// Print outputs the application name and version string.
+func Print() {
+	v := Version()
+	fmt.Printf("%s version %s\n", appName, v.Version)
+}
+
+// PrintFull prints the application name and detailed version information.
+func PrintFull() {
+	v := Version()
+	fmt.Printf("%s - version %s\n", appName, v.Version)
+	fmt.Printf("  branch: \t%s\n", v.Branch)
+	fmt.Printf("  revision: \t%s\n", v.Revision)
+	fmt.Printf("  build date: \t%s\n", v.BuildDate)
+	fmt.Printf("  build user: \t%s\n", v.BuildUser)
+	fmt.Printf("  go version: \t%s\n", v.GoVersion)
+}
+
+// Handler returns an HTTP Handler which returns JSON formatted version information.
+func Handler() http.Handler {
+	v := Version()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		enc.Encode(v)
+	})
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,49 @@
+/*
+MIT License
+
+Copyright (c) 2017 Kolide
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package version
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVersion(t *testing.T) {
+	now := time.Now().String()
+	version = "test"
+	buildDate = now
+
+	info := Version()
+
+	if have, want := info.Version, version; have != want {
+		t.Errorf("have %s, want %s", have, want)
+	}
+
+	if have, want := info.BuildDate, now; have != want {
+		t.Errorf("have %s, want %s", have, want)
+	}
+
+	if have, want := info.BuildUser, "unknown"; have != want {
+		t.Errorf("have %s, want %s", have, want)
+	}
+}


### PR DESCRIPTION
## Summary of changes:
* Updated the Makefile
* Updated deps
* Add the [cobra](https://github.com/spf13/cobra/) library for cli arguments
* Switch to `filepath.Join` instead of `strings.Join` to get the path to the config file
* Minor readme update

## CLI output
Samples of the CLI output shown below. I've tested all of these changes on windows, it was just easier to copy/paste on my main box. Also, note this doesn't affect the upload action when no arguments are passed. In the future, we could add other arguments like verbose output.


```bash
$ ./build/darwin/gosal version
gosal version e023f5b-dirty
```

```bash
$ ./build/darwin/gosal version --full
gosal - version e023f5b-dirty
  branch: 	updates
  revision: 	e023f5b30f28ffd3b0908e094c158779c4a5b2e2
  build date: 	2017-12-24T05:48:16Z
  build user: 	clburlison
  go version: 	go1.9.2
```

```bash
$ ./build/darwin/gosal help
Gosal is intended to be a multi platform client for sal.

Complete documentation is available at https://github.com/airbnb/gosal/.

Usage:
  gosal [flags]
  gosal [command]

Available Commands:
  help        Help about any command
  version     Print the version number of gosal

Flags:
  -h, --help     help for gosal

Use "gosal [command] --help" for more information about a command.
```

The version code is mostly based off [kolide/fleet](https://github.com/kolide/fleet) and [kolide/kit](https://github.com/kolide/kit/tree/master/version). 

Additional details in the specific git commit messages. Most of the changes I've made should make testing/future development easier.