### PR TITLE
scaffold cross platform reports builder

### DIFF
--- a/xpreports/build_darwin.go
+++ b/xpreports/build_darwin.go
@@ -1,0 +1,29 @@
+package xpreports
+
+import (
+	"os/exec"
+
+	"github.com/groob/plist"
+)
+
+// buildReport creates a report using macOS APIs and paths.
+func buildReport() (*Report, error) {
+	// some code which would only work on macOS
+	// ignore what it actually does, it's just there for demo.
+
+	out, err := exec.Command("/usr/sbin/system_profiler", "SPHardwareDataType", "SPSoftwareDataType", "-xml").CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	var spData = struct {
+		DetailType string `plist:"_dataType"`
+	}{}
+
+	if err := plist.Unmarshal(out, &spData); err != nil {
+		return nil, err
+	}
+
+	report := &Report{Serial: "APPLSERIAL"}
+	return report, nil
+}

--- a/xpreports/build_linux.go
+++ b/xpreports/build_linux.go
@@ -1,0 +1,6 @@
+package xpreports
+
+// buildReport creates a report using linux APIs and paths.
+func buildReport() (*Report, error) {
+	panic("boom: I ran some linux code")
+}

--- a/xpreports/build_windows.go
+++ b/xpreports/build_windows.go
@@ -1,0 +1,6 @@
+package xpreports
+
+// buildReport creates a report using windows APIs and paths.
+func buildReport() (*Report, error) {
+	panic("boom: I ran code specific to windows")
+}

--- a/xpreports/reports.go
+++ b/xpreports/reports.go
@@ -1,0 +1,23 @@
+// Package xpreports implements cross-platform sal reports.
+package xpreports
+
+type Report struct {
+	Serial          string `json:"serial"`
+	Key             string `json:"key"`
+	Name            string `json:"name"`
+	DiskSize        string `json:"disk_size"`
+	SalVersion      string `json:"sal_version"`
+	RunUUID         string `json:"run_uuid"`
+	Base64bz2Report string `json:"base_64_bz_2_report"`
+}
+
+// Build creates a report for the sal server.
+// Build supports darwin, windows and linux and will use
+// the appropriate APIs for each system.
+func Build() (*Report, error) {
+
+	// buildReport is implented separately for each
+	// operating system.
+	report, err := buildReport()
+	return report, err
+}


### PR DESCRIPTION
This package demonstrates the use of Go build tags to create a report builder which compiles with a specific implementation for each OS.
More on build tags here https://dave.cheney.net/2013/10/12/how-to-use-conditional-compilation-with-the-go-build-tool

This PR is not intended to be merged, it's a proof of concept for the https://github.com/airbnb/gosal/issues/23