### PR TITLE
Convert disk space from bytes to kilobytes

### DIFF
--- a/reports/win32_logicaldisk.go
+++ b/reports/win32_logicaldisk.go
@@ -43,8 +43,8 @@ func GetCDrive() (Win32LogicalDisk, error) {
 	for _, element := range disks {
 		if element.Name == "C:" {
 			c.Name = element.Name
-			c.Size = element.Size
-			c.FreeSpace = element.FreeSpace
+			c.Size = (element.Size / 1024)
+			c.FreeSpace = (element.FreeSpace / 1024)
 		}
 	}
 


### PR DESCRIPTION
Fixes issue #29 by converting disk space unit received from wmi(bytes) to the unit that the server expects(kilobytes).