### PR TITLE
fix: Properly test linting with CI exit codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ go:
   - 1.8.x
   - master
 
-script: make deps && make test
+script: make deps && make test && make lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8.x
+  - 1.9.x
   - master
 
 script: make deps && make test && make lint

--- a/Makefile
+++ b/Makefile
@@ -93,4 +93,5 @@ lint:
 	  echo "^- Repo contains improperly formatted go files; run gofmt -w *.go" && exit 1; \
 	  else echo "All .go files formatted correctly"; fi
 	go vet ./...
-	for pkg in $$(go list ./... |grep -v /vendor/); do golint $$pkg; done
+	# Bandaid until https://github.com/golang/lint/pull/325 is merged
+	golint -set_exit_status `go list ./... | grep -v /vendor/`

--- a/cmd/gosal/gosal.go
+++ b/cmd/gosal/gosal.go
@@ -42,7 +42,7 @@ func createRootCmd(conf *config.Config) *cobra.Command {
 Complete documentation is available at https://github.com/airbnb/gosal/.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if !conf.Loaded() {
-				fatal(errors.New("config file not loaded. Must specify --config flag."))
+				fatal(errors.New("config file not loaded. Must specify --config flag"))
 			}
 			if err := sal.SendCheckin(conf); err != nil {
 				fatal(err)

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 )
 
-//  New creates a Config from a JSON file.
+// New creates a Config from a JSON file.
 func New(path string) (*Config, error) {
 	file, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/reports/emulator_machineinfo.go
+++ b/reports/emulator_machineinfo.go
@@ -65,8 +65,8 @@ func GetHardwareInfo() (*HardwareInfo, error) {
 	strMemory := ""
 
 	for convertedMemory >= 1024 {
-		convertedMemory = convertedMemory /1024
-		unitCount ++
+		convertedMemory = convertedMemory / 1024
+		unitCount++
 	}
 
 	switch unitCount {

--- a/version/version.go
+++ b/version/version.go
@@ -23,23 +23,23 @@ SOFTWARE.
 */
 
 /*
-	Package version provides utilities for displaying version information about a Go application.
+Package version provides utilities for displaying version information about a Go application.
 
-	To use this package, a program would set the package variables at build time, using the
-	-ldflags go build flag.
+To use this package, a program would set the package variables at build time, using the
+-ldflags go build flag.
 
-	Example:
-		go build -ldflags "-X github.com/kolide/kit/version.version=1.0.0"
+Example:
+    go build -ldflags "-X github.com/kolide/kit/version.version=1.0.0"
 
-	Available values and defaults to use with ldflags:
+Available values and defaults to use with ldflags:
 
-		version   = "unknown"
-		branch    = "unknown"
-		revision  = "unknown"
-		goVersion = "unknown"
-		buildDate = "unknown"
-		buildUser = "unknown"
-		appName   = "unknown"
+    version   = "unknown"
+    branch    = "unknown"
+    revision  = "unknown"
+    goVersion = "unknown"
+    buildDate = "unknown"
+    buildUser = "unknown"
+    appName   = "unknown"
 
 */
 package version


### PR DESCRIPTION
This will run `make lint` with proper exit codes during CI.