### PR TITLE
Adds a 30 sec timeout to checkin

### DIFF
--- a/sal/sal.go
+++ b/sal/sal.go
@@ -4,9 +4,9 @@ package sal
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
-	"net"
 	"os"
 	"strings"
 	"time"

--- a/sal/sal.go
+++ b/sal/sal.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -55,10 +56,17 @@ func (c *Client) Checkin(values url.Values) error {
 	// We're sending URLEncoded data in the body, so tell the server what to expect
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	// Configure 30 second timeout
-	timeout := time.Duration(30 * time.Second)
+	// Configure new http.client with timeouts
 	httpclient := http.Client{
-		Timeout: timeout,
+		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   5 * time.Second,
+				KeepAlive: 5 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
 	}
 
 	// Execute the request

--- a/sal/sal.go
+++ b/sal/sal.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/airbnb/gosal/config"
 	"github.com/airbnb/gosal/reports"
@@ -54,8 +55,14 @@ func (c *Client) Checkin(values url.Values) error {
 	// We're sending URLEncoded data in the body, so tell the server what to expect
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
+	// Configure 30 second timeout
+	timeout := time.Duration(30 * time.Second)
+	httpclient := http.Client{
+		Timeout: timeout,
+	}
+
 	// Execute the request
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpclient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to checkin: %s", err)
 	}


### PR DESCRIPTION
Addresses part of #33 by adding a timeout to the checkin http request. Currently hard coded to 30 seconds, but that feels too long to me. If the server doesn't respond in 5 seconds, it will probably never respond.