### PR TITLE
emulate managed installs report

### DIFF
--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -3,6 +3,7 @@ package windows
 import (
 	"bytes"
 	"encoding/base64"
+	"fmt"
 	"strings"
 
 	"github.com/airbnb/gosal/config"
@@ -28,6 +29,18 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "bz2: failed to get facts")
 	}
+
+	// installs, err := GetManagedInstalls()
+	// if err != nil {
+	// 	return "", errors.Wrap(err, "message")
+	// }
+
+	test, err := MarshalManagedInstallFields()
+	if err != nil {
+		return "", errors.Wrap(err, "message")
+	}
+
+	fmt.Println(test)
 
 	cDrive, err := GetCDrive()
 	if err != nil {

--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -30,7 +30,7 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 		return "", errors.Wrap(err, "bz2: failed to get facts")
 	}
 
-	installs, err := UnmarshalManagedInstallsFormatted()
+	installs, err := CreateManagedInstalls()
 	if err != nil {
 		return "", errors.Wrap(err, "message")
 	}

--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -3,7 +3,6 @@ package windows
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"strings"
 
 	"github.com/airbnb/gosal/config"
@@ -19,6 +18,7 @@ type basereport struct {
 	OSFamily           string
 	MachineInfo        *MachineInfo
 	Facter             cm.Facts
+	ManagedInstalls    Installs
 }
 
 // BuildBase64bz2Report will return a compressed and encoded string of our report struct
@@ -30,17 +30,10 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 		return "", errors.Wrap(err, "bz2: failed to get facts")
 	}
 
-	// installs, err := GetManagedInstalls()
-	// if err != nil {
-	// 	return "", errors.Wrap(err, "message")
-	// }
-
-	test, err := MarshalManagedInstallFields()
+	installs, err := UnmarshalManagedInstallsFormatted()
 	if err != nil {
 		return "", errors.Wrap(err, "message")
 	}
-
-	fmt.Println(test)
 
 	cDrive, err := GetCDrive()
 	if err != nil {
@@ -63,6 +56,7 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 		ConsoleUser:        strings.Split(computerSystem.UserName, "\\")[1],
 		OSFamily:           "Windows",
 		Facter:             facts,
+		ManagedInstalls:    installs,
 	}
 
 	encodedReport, err := report.CompressAndEncode()

--- a/xpreports/windows/managedinstalls.go
+++ b/xpreports/windows/managedinstalls.go
@@ -27,15 +27,15 @@ func GetManagedInstalls() ([]ManagedInstalls, error) {
 }
 
 // marshalManagedInstallFields takes a golang struct and uses field tags to conver to what sal wants
-func MarshalManagedInstallFields() ([]ManagedInstallsFormatted, error) {
+func MarshalManagedInstallFields() ([]byte, error) {
 
 	mi, err := GetManagedInstalls()
 	if err != nil {
 		return nil, errors.Wrap(err, "message")
 	}
-
+	var all []ManagedInstallsFormatted
 	for _, element := range mi {
-		json.Marshal(&ManagedInstallsFormatted{
+		all = append(all, ManagedInstallsFormatted{
 			Description:      element.Description,
 			DisplayName:      element.DisplayName,
 			Installed:        element.Installed,
@@ -46,10 +46,27 @@ func MarshalManagedInstallFields() ([]ManagedInstallsFormatted, error) {
 
 	}
 
-	// fmt.Println(string(mif))
+	data, err := json.MarshalIndent(&all, "", "  ")
 
-	return nil, nil
+	return data, nil
 }
+
+func UnmarshalManagedInstallsFormatted() (Installs, error) {
+	mmif, err := MarshalManagedInstallFields()
+	if err != nil {
+		return nil, errors.Wrap(err, "message")
+	}
+
+	var i Installs
+
+	if err := json.Unmarshal(mmif, &i); err != nil {
+		return nil, errors.Wrap(err, "failed unmarshalling Facts")
+	}
+
+	return i, nil
+}
+
+type Installs []map[string]interface{}
 
 type ManagedInstallsFormatted struct {
 	Description      string `json:"description"`

--- a/xpreports/windows/managedinstalls.go
+++ b/xpreports/windows/managedinstalls.go
@@ -3,38 +3,55 @@ package windows
 import (
 	"encoding/json"
 	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
 )
 
 // GetManagedInstalls is a crappy representation of things installed on a windows client
-func GetManagedInstalls() ([]ManagedInstalls, error) {
+func get32BitPrograms() ([]Program, error) {
 	cmd := exec.Command("powershell", "gp", "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*", "|", "ConvertTo-Json")
 
 	// cmd.Stderr = os.Stderr
 	o, err := cmd.Output()
 	if err != nil {
-		return nil, errors.Wrap(err, "exec gp")
+		return nil, errors.Wrap(err, "exec gp 32 bit programs")
 	}
 
-	var j []ManagedInstalls
+	var p []Program
 
-	if err := json.Unmarshal(o, &j); err != nil {
-		return nil, errors.Wrap(err, "failed unmarshalling Installs")
+	if err := json.Unmarshal(o, &p); err != nil {
+		return nil, errors.Wrap(err, "failed unmarshalling 32 bit programs")
 	}
 
-	return j, nil
+	return p, nil
+}
+
+// GetManagedInstalls is a crappy representation of things installed on a windows client
+func get64BitPrograms() ([]Program, error) {
+	cmd := exec.Command("powershell", "gp", "HKLM:\\Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*", "|", "ConvertTo-Json")
+
+	// cmd.Stderr = os.Stderr
+	o, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrap(err, "exec gp 64 bit programs")
+	}
+
+	var p []Program
+
+	if err := json.Unmarshal(o, &p); err != nil {
+		return nil, errors.Wrap(err, "failed unmarshalling 64 bit programs")
+	}
+
+	return p, nil
 }
 
 // marshalManagedInstallFields takes a golang struct and uses field tags to conver to what sal wants
-func MarshalManagedInstallFields() ([]byte, error) {
+func formatManagedInstallFields(p []Program) ([]byte, error) {
 
-	mi, err := GetManagedInstalls()
-	if err != nil {
-		return nil, errors.Wrap(err, "message")
-	}
 	var all []ManagedInstallsFormatted
-	for _, element := range mi {
+
+	for _, element := range p {
 		all = append(all, ManagedInstallsFormatted{
 			Description:      element.Description,
 			DisplayName:      element.DisplayName,
@@ -43,31 +60,76 @@ func MarshalManagedInstallFields() ([]byte, error) {
 			InstalledVersion: element.InstalledVersion,
 			Name:             element.Name,
 		})
-
 	}
 
 	data, err := json.MarshalIndent(&all, "", "  ")
-
-	return data, nil
-}
-
-func UnmarshalManagedInstallsFormatted() (Installs, error) {
-	mmif, err := MarshalManagedInstallFields()
 	if err != nil {
 		return nil, errors.Wrap(err, "message")
 	}
 
+	return data, nil
+}
+
+// filterManagedInstalls strips out things "apps and programs" wouldn't report to the user (i.e MS Patches, etc)
+func filterManagedInstalls(p []Program) ([]Program, error) {
+
+	var filtered []Program
+
+	for _, element := range p {
+		if element.DisplayName == "" || strings.Contains(element.Name, "0FF1CE") {
+			continue
+		} else {
+			filtered = append(filtered, Program{
+				Description:      element.Description,
+				DisplayName:      element.DisplayName,
+				Installed:        element.Installed,
+				InstalledSize:    element.InstalledSize,
+				InstalledVersion: element.InstalledVersion,
+				Name:             element.Name,
+			})
+		}
+	}
+
+	return filtered, nil
+}
+
+// CreateManagedInstalls returns a formatted and filtered list of apps installed (what you see in programs and features)
+func CreateManagedInstalls() (Installs, error) {
+	programs64, err := get64BitPrograms()
+	if err != nil {
+		return nil, errors.Wrap(err, "message")
+	}
+
+	programs32, err := get32BitPrograms()
+	if err != nil {
+		return nil, errors.Wrap(err, "message")
+	}
+
+	p := append(programs32[:], programs64[:]...)
+
+	fi, err := filterManagedInstalls(p)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to filter programs")
+	}
+
+	fo, err := formatManagedInstallFields(fi)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to format programs")
+	}
+
 	var i Installs
 
-	if err := json.Unmarshal(mmif, &i); err != nil {
-		return nil, errors.Wrap(err, "failed unmarshalling Facts")
+	if err := json.Unmarshal(fo, &i); err != nil {
+		return nil, errors.Wrap(err, "failed unmarshalling installs")
 	}
 
 	return i, nil
 }
 
+// Installs is what is returned to bas64bz2.go
 type Installs []map[string]interface{}
 
+// ManagedInstallsFormatted is for remapping the CamelCase keys to snake_case
 type ManagedInstallsFormatted struct {
 	Description      string `json:"description"`
 	DisplayName      string `json:"display_name"`
@@ -77,20 +139,12 @@ type ManagedInstallsFormatted struct {
 	Name             string `json:"name"`
 }
 
-// ManagedInstalls array of dicts
-//   description string
-//   display_name string
-//   installed bool
-//   installed_size int
-//   installed_version string
-//   name string
-
-// ManagedInstalls data structure that tries to mirror how munki works (but fails mostly)
-type ManagedInstalls struct {
+// Program data structure that tries to mirror how munki works (but fails mostly)
+type Program struct {
 	Description      string `json:"Comments"` // MS doesn't carry descriptions, this is close
 	DisplayName      string `json:"DisplayName"`
 	Installed        bool   // MS ins't munki so this will just default true
 	InstalledSize    int    `json:"EstimatedSize"`
 	InstalledVersion string `json:"DisplayVersion"`
-	Name             string `json:"PSChildName"` // UUID of the installed item
+	Name             string `json:"PSChildName"` // UUID of the items uninstaller
 }

--- a/xpreports/windows/managedinstalls.go
+++ b/xpreports/windows/managedinstalls.go
@@ -1,0 +1,79 @@
+package windows
+
+import (
+	"encoding/json"
+	"os/exec"
+
+	"github.com/pkg/errors"
+)
+
+// GetManagedInstalls is a crappy representation of things installed on a windows client
+func GetManagedInstalls() ([]ManagedInstalls, error) {
+	cmd := exec.Command("powershell", "gp", "HKLM:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*", "|", "ConvertTo-Json")
+
+	// cmd.Stderr = os.Stderr
+	o, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrap(err, "exec gp")
+	}
+
+	var j []ManagedInstalls
+
+	if err := json.Unmarshal(o, &j); err != nil {
+		return nil, errors.Wrap(err, "failed unmarshalling Installs")
+	}
+
+	return j, nil
+}
+
+// marshalManagedInstallFields takes a golang struct and uses field tags to conver to what sal wants
+func MarshalManagedInstallFields() ([]ManagedInstallsFormatted, error) {
+
+	mi, err := GetManagedInstalls()
+	if err != nil {
+		return nil, errors.Wrap(err, "message")
+	}
+
+	for _, element := range mi {
+		json.Marshal(&ManagedInstallsFormatted{
+			Description:      element.Description,
+			DisplayName:      element.DisplayName,
+			Installed:        element.Installed,
+			InstalledSize:    element.InstalledSize,
+			InstalledVersion: element.InstalledVersion,
+			Name:             element.Name,
+		})
+
+	}
+
+	// fmt.Println(string(mif))
+
+	return nil, nil
+}
+
+type ManagedInstallsFormatted struct {
+	Description      string `json:"description"`
+	DisplayName      string `json:"display_name"`
+	Installed        bool   `json:"installed"`
+	InstalledSize    int    `json:"installed_size"`
+	InstalledVersion string `json:"installed_version"`
+	Name             string `json:"name"`
+}
+
+// ManagedInstalls array of dicts
+//   description string
+//   display_name string
+//   installed bool
+//   installed_size int
+//   installed_version string
+//   name string
+
+// ManagedInstalls data structure that tries to mirror how munki works (but fails mostly)
+type ManagedInstalls struct {
+	Description      string `json:"Comments"` // MS doesn't carry descriptions, this is close
+	DisplayName      string `json:"DisplayName"`
+	Installed        bool   // MS ins't munki so this will just default true
+	InstalledSize    int    `json:"EstimatedSize"`
+	InstalledVersion string `json:"DisplayVersion"`
+	Name             string `json:"PSChildName"` // UUID of the installed item
+}


### PR DESCRIPTION
so this is modeling (basically) what the managed installs report second is.

the thing that doesn't work is the json field mappings.  golang structs dont export in snake_case, so i need to figure out how to do that.  my thought was to use `Marshal` because you can use field mappings, but the current implementation of how i understand it is failing.