### PR TITLE
Add actual version string to report

### DIFF
--- a/xpreports/build_windows.go
+++ b/xpreports/build_windows.go
@@ -3,8 +3,8 @@ package xpreports
 import (
 	"strconv"
 
-	"github.com/1dustindavis/gosal/version"
 	"github.com/airbnb/gosal/config"
+	"github.com/airbnb/gosal/version"
 	"github.com/airbnb/gosal/xpreports/windows"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"

--- a/xpreports/build_windows.go
+++ b/xpreports/build_windows.go
@@ -7,6 +7,7 @@ import (
 	"github.com/airbnb/gosal/config"
 	"github.com/airbnb/gosal/xpreports/windows"
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 )
 
 // buildReport creates a report using windows APIs and paths.

--- a/xpreports/build_windows.go
+++ b/xpreports/build_windows.go
@@ -3,10 +3,10 @@ package xpreports
 import (
 	"strconv"
 
+	"github.com/1dustindavis/gosal/version"
 	"github.com/airbnb/gosal/config"
 	"github.com/airbnb/gosal/xpreports/windows"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
 )
 
 // buildReport creates a report using windows APIs and paths.
@@ -28,12 +28,15 @@ func buildReport(conf *config.Config) (*Report, error) {
 		return nil, errors.Wrap(err, "reports: getting plist")
 	}
 
+	// Get version information
+	v := version.Version()
+
 	report := &Report{
 		Serial:          win32Bios.SerialNumber,
 		Key:             conf.Key,
 		Name:            win32Bios.PSComputerName,
 		DiskSize:        strconv.Itoa(CDrive.Size),
-		SalVersion:      strconv.Itoa(1),
+		SalVersion:      v.Version,
 		RunUUID:         u1,
 		Base64bz2Report: encodedCompressedPlist,
 	}


### PR DESCRIPTION
This adds the real version string to the report that is sent to Sal. Currently, the makefile sets this version number to the commit, but will use a tag if/when there are actual gosal releases.