### PR TITLE
add StartTime key to report data

### DIFF
--- a/xpreports/build_windows.go
+++ b/xpreports/build_windows.go
@@ -6,7 +6,7 @@ import (
 	"github.com/airbnb/gosal/config"
 	"github.com/airbnb/gosal/xpreports/windows"
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 // buildReport creates a report using windows APIs and paths.

--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"strings"
+	"time"
 
 	"github.com/airbnb/gosal/config"
 	"github.com/airbnb/gosal/xpreports/cm"
@@ -18,6 +19,7 @@ type basereport struct {
 	OSFamily           string
 	MachineInfo        *MachineInfo
 	Facter             cm.Facts
+	StartTime          string
 }
 
 // BuildBase64bz2Report will return a compressed and encoded string of our report struct
@@ -45,6 +47,7 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 	}
 
 	report := basereport{
+		StartTime:          time.Now().Format("01-02-2006"),
 		AvailableDiskSpace: cDrive.FreeSpace,
 		MachineInfo:        machineInfo,
 		ConsoleUser:        strings.Split(computerSystem.UserName, "\\")[1],


### PR DESCRIPTION
adds a `StartTime` key to the base report.

This is expected to be present in sal 3.3.13 from what I can tell.
https://github.com/salopensource/sal/blob/master/server/non_ui_views.py#L479