### PR TITLE
handle case where admin does not define a management block

### DIFF
--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -26,10 +26,14 @@ type basereport struct {
 func BuildBase64bz2Report(conf *config.Config) (string, error) {
 	var facts map[string]interface{}
 
-	facts, err := cm.GetFacts(conf.Management.Tool, conf.Management.Path, conf.Management.Command)
-	if err != nil {
-		return "", errors.Wrap(err, "bz2: failed to get facts")
+	if conf.Management != nil {
+		facts, err := cm.GetFacts(conf.Management.Tool, conf.Management.Path, conf.Management.Command)
+		_ = facts // not sure how to handle unused variable other than this.
+		if err != nil {
+			return "", errors.Wrap(err, "bz2: failed to get facts")
+		}
 	}
+	// fmt.Printf("%+v\n", conf)
 
 	cDrive, err := GetCDrive()
 	if err != nil {

--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -33,7 +33,6 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 			return "", errors.Wrap(err, "bz2: failed to get facts")
 		}
 	}
-	// fmt.Printf("%+v\n", conf)
 
 	cDrive, err := GetCDrive()
 	if err != nil {


### PR DESCRIPTION
gosal silently just fails if the admin doesn't define a configuration management tool or `management` block in the config file.  this handles the case where the block is `nil`