### PR TITLE
fix incorrect variable scope

### DIFF
--- a/xpreports/windows/base64bz2.go
+++ b/xpreports/windows/base64bz2.go
@@ -27,11 +27,7 @@ func BuildBase64bz2Report(conf *config.Config) (string, error) {
 	var facts map[string]interface{}
 
 	if conf.Management != nil {
-		facts, err := cm.GetFacts(conf.Management.Tool, conf.Management.Path, conf.Management.Command)
-		_ = facts // not sure how to handle unused variable other than this.
-		if err != nil {
-			return "", errors.Wrap(err, "bz2: failed to get facts")
-		}
+		facts, _ = cm.GetFacts(conf.Management.Tool, conf.Management.Path, conf.Management.Command)
 	}
 
 	cDrive, err := GetCDrive()


### PR DESCRIPTION
https://github.com/airbnb/gosal/pull/45 will never work due to bad variable scoping.  this will properly assign the variable in case config management is configured.