### PR TITLE
[sal4] add win 10 version

### DIFF
--- a/xpreports/build_windows.go
+++ b/xpreports/build_windows.go
@@ -62,7 +62,7 @@ func buildMachineReport(conf *config.Config) (*Machine, error) {
 			HostName:             bios.PSComputerName,
 			ConsoleUser:          computerSystem.UserName,
 			OSFamily:             "Windows",
-			OperatingSystem:      os.Caption,
+			OperatingSystem:      os.Caption + " " + os.Version,
 			HDSpace:              disk.FreeSpace,
 			HDTotal:              disk.Size,
 			MachineModel:         computerSystem.Model,

--- a/xpreports/windows/win32_os.go
+++ b/xpreports/windows/win32_os.go
@@ -29,6 +29,7 @@ func GetWin32OS() (Win32OS, error) {
 // Win32OS structure
 type Win32OS struct {
 	Caption                string `json:"Caption"` // os version
+	Version                string `json:"Version"`
 	TotalVirtualMemorySize int    `json:"TotalVirtualMemorySize"`
 	TotalVisibleMemorySize int    `json:"TotalVisibleMemorySize"`
 }


### PR DESCRIPTION
The following add's the windows build number to the OS caption so it would be `Windows 10 Pro - 1903`

This will split the OS Widget on the dashboard and make it rather large for windows a possible if you have lots of different OS types and installs. option is only including the build number or applying a filter on the display inside SAL itself.