### PR TITLE
Gosal - Linux Do proper unit conversion from bytes to kb

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _Due to major changes in Sal4's checkin method, people who run Sal3 should check
 
 ## Overview
 
-Gosal is intended to be a multi platform client for sal.
+Gosal is intended to be a multi platform client for sal, Gosal does not provide a complete 1-2-1 mapping of reporting info compared to Sal for macOS PRs are welcome.
 
 ## Getting Started
 
@@ -13,7 +13,7 @@ Your configuration file should be `json` formatted as follows:
 ```json
 {
   "key": "your gigantic machine group key",
-  "url": "https://urltoyourserver.com/",
+  "url": "https://urltoyourserver.com",
   "management": {
     "tool": "puppet",
     "path": "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\puppet.bat",
@@ -39,7 +39,7 @@ make deps
 make build
 ```
 
-New macOS and windows binaries will be added to the `build/` directory.
+Gosal OS specific binaries will be added to the `build/` directory.
 
 # Building Sal4
 

--- a/xpreports/build_linux.go
+++ b/xpreports/build_linux.go
@@ -37,6 +37,7 @@ func buildMachineReport(conf *config.Config) (*Machine, error) {
 		return nil, errors.Wrap(err, "reports: getting console user")
 	}
 
+	//Return the underling linux meminfo detail in bytes
 	v, _ := mem.VirtualMemory()
 
 	computerSystem, err := linux.GetComputerSystem()
@@ -44,7 +45,7 @@ func buildMachineReport(conf *config.Config) (*Machine, error) {
 		return nil, errors.Wrap(err, "reports: getting computerSystem")
 	}
 
-	// Convert memory from kb to correct size
+	// Convert memory from bytes to a human readable size format
 	convertedMemory := float64(v.Total)
 	var unitCount int
 	var strMemory string
@@ -82,7 +83,7 @@ func buildMachineReport(conf *config.Config) (*Machine, error) {
 			CPUType:              cpu.CPUType,
 			CPUSpeed:             cpu.CurrentProcessorSpeed,
 			Memory:               strMemory,
-			MemoryKB:             int(v.Total),
+			MemoryKB:             int(v.Total) / 1024,
 		}, Facts: &MachineFacts{
 			CheckinModuleVersion: "1",
 		},


### PR DESCRIPTION
Following a conversation in slack, it was noted that the memory in KB returned by Gosal on Linux was returning a value out by an order of a 1000 causing writes to the DB to fail. 

The following corrects this issue and provides some user-facing docs improvements. 


